### PR TITLE
HTTP requests

### DIFF
--- a/Assets/Scripts/Commons/Requesters.meta
+++ b/Assets/Scripts/Commons/Requesters.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: def6dea6bd085a843abb1c088f2dd785
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Commons/Requesters/ARPB2Requester.cs
+++ b/Assets/Scripts/Commons/Requesters/ARPB2Requester.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class ARPB2Requester 
+{
+
+    public readonly static string BASE_URL = "http://18.188.179.106:5555";
+
+}

--- a/Assets/Scripts/Commons/Requesters/ARPB2Requester.cs
+++ b/Assets/Scripts/Commons/Requesters/ARPB2Requester.cs
@@ -7,4 +7,9 @@ public class ARPB2Requester
 
     public readonly static string BASE_URL = "http://18.188.179.106:5555";
 
+    protected static void onDefaultFailure(string error)
+    {
+        Debug.LogError("HTTP request failed: " + error);
+    }
+
 }

--- a/Assets/Scripts/Commons/Requesters/ARPB2Requester.cs.meta
+++ b/Assets/Scripts/Commons/Requesters/ARPB2Requester.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c46d0c3fe3dba2b48a48352896af6c18
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Commons/Requesters/LevelSpecificationRequester.cs
+++ b/Assets/Scripts/Commons/Requesters/LevelSpecificationRequester.cs
@@ -1,28 +1,29 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Networking;
 
 public class LevelSpecificationRequester : ARPB2Requester
 { 
-
     public readonly static string LEVEL_PATH = "/levels/{0}";
     
-    public static IEnumerator Get(int levelNo)
+    public static IEnumerator Get(int levelNo, Action<LevelSpecification> onSuccess, Action<string> onFailure = null)
     {
+        Debug.Log(">>> LevelSpecificationRequester.Get");
         UnityWebRequest www = UnityWebRequest.Get(GetLevelSpecificationURL(levelNo));
         yield return www.SendWebRequest();
 
         if (!www.isNetworkError && !www.isHttpError)
         {
-            Debug.Log("Level JSON: " + www.downloadHandler.text);
+            Debug.Log(">>> Level JSON: " + www.downloadHandler.text);
+            onSuccess(LevelSpecification.Load(www.downloadHandler.text));
         }
-        else
+        else if (onFailure != null)
         {
             Debug.LogError("HTTP REQUEST ERROR: " + www.error);
+            onFailure(www.error);
         }
-
-        //return LevelSpecification.Load(DEBUG_SPEC);
     }
 
     public static string GetLevelSpecificationURL(int levelId)

--- a/Assets/Scripts/Commons/Requesters/LevelSpecificationRequester.cs
+++ b/Assets/Scripts/Commons/Requesters/LevelSpecificationRequester.cs
@@ -1,0 +1,33 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Networking;
+
+public class LevelSpecificationRequester : ARPB2Requester
+{ 
+
+    public readonly static string LEVEL_PATH = "/levels/{0}";
+    
+    public static IEnumerator Get(int levelNo)
+    {
+        UnityWebRequest www = UnityWebRequest.Get(GetLevelSpecificationURL(levelNo));
+        yield return www.SendWebRequest();
+
+        if (!www.isNetworkError && !www.isHttpError)
+        {
+            Debug.Log("Level JSON: " + www.downloadHandler.text);
+        }
+        else
+        {
+            Debug.LogError("HTTP REQUEST ERROR: " + www.error);
+        }
+
+        //return LevelSpecification.Load(DEBUG_SPEC);
+    }
+
+    public static string GetLevelSpecificationURL(int levelId)
+    {
+        return string.Format(BASE_URL + LEVEL_PATH, levelId);
+    }
+
+}

--- a/Assets/Scripts/Commons/Requesters/LevelSpecificationRequester.cs
+++ b/Assets/Scripts/Commons/Requesters/LevelSpecificationRequester.cs
@@ -16,13 +16,15 @@ public class LevelSpecificationRequester : ARPB2Requester
 
         if (!www.isNetworkError && !www.isHttpError)
         {
-            Debug.Log(">>> Level JSON: " + www.downloadHandler.text);
             onSuccess(LevelSpecification.Load(www.downloadHandler.text));
         }
         else if (onFailure != null)
         {
-            Debug.LogError("HTTP REQUEST ERROR: " + www.error);
             onFailure(www.error);
+        }
+        else
+        {
+            onDefaultFailure(www.error);
         }
     }
 

--- a/Assets/Scripts/Commons/Requesters/LevelSpecificationRequester.cs.meta
+++ b/Assets/Scripts/Commons/Requesters/LevelSpecificationRequester.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0177d48676cfd0542b3f24a2c755a565
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/LevelScene/LevelController.cs
+++ b/Assets/Scripts/LevelScene/LevelController.cs
@@ -40,7 +40,8 @@ namespace ARPB2
         public void Start()
         {
             DebugArrows.SetActive(false);
-            LevelSpecification = LevelSpecification.Load("{\"minimal_dimensions\":{\"rows\":2,\"columns\":3}}");
+            LevelSpecificationRequester.Get(1);
+            LevelSpecification = LevelSpecification.LoadDebug();
             PlatformGenerator.PlatformRequirements = LevelSpecification.GeneratePlatformRequirements();
             PlatformGenerator.SetOnDetectionFinishedListener(_OnDetectionFinished);
         }

--- a/Assets/Scripts/LevelScene/LevelController.cs
+++ b/Assets/Scripts/LevelScene/LevelController.cs
@@ -39,8 +39,8 @@ namespace ARPB2
 
         public void Start()
         {
+            Debug.Log(">>> LevelController starts");
             DebugArrows.SetActive(false);
-            LevelSpecificationRequester.Get(1);
             LevelSpecification = LevelSpecification.LoadDebug();
             PlatformGenerator.PlatformRequirements = LevelSpecification.GeneratePlatformRequirements();
             PlatformGenerator.SetOnDetectionFinishedListener(_OnDetectionFinished);

--- a/Assets/Scripts/LevelScene/LevelSpecification.cs
+++ b/Assets/Scripts/LevelScene/LevelSpecification.cs
@@ -17,10 +17,22 @@ public class LevelSpecification
     [JsonProperty("minimal_dimensions.columns")]
     public int Columns { get; set; }
 
+    private static string DEBUG_SPEC = "" +
+        "{" +
+        "  \"minimal_dimensions\": {" +
+        "    \"rows\": 2," +
+        "    \"columns\": 3" +
+        "  }" +
+        "}";
 
     public static LevelSpecification Load(string json)
     {
         return JsonConvert.DeserializeObject<LevelSpecification>(json);
+    }
+
+    public static LevelSpecification LoadDebug()
+    {
+        return Load(DEBUG_SPEC);
     }
 
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
-# arpb2-project
+# ARPB2 project
+
+### Utils
+
+#### See logs
+
+`adb.exe logcat -s Unity PackageManager dalvikvm DEBUG`


### PR DESCRIPTION
On this PR we implement HTTP requests. 

The methods need to be called as Unity coroutines. So, for example, to fetch a LevelSpecification you should run 

`StartCoroutine( LevelSpecificationRequester.Get(levelNo, onSuccessCallback) )`

Note that the function `StartCoroutine` is implemented on MonoBeheviour